### PR TITLE
Solve a problem building the containers

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -2,11 +2,12 @@ FROM vanessa/slurm:18.08.6
 
 # This container will be built on docker-compose up -d
 
+RUN pip install numpy==1.12 && pip install websockify
+
 RUN yum install -y nc && \
     wget https://turbovnc.org/pmwiki/uploads/Downloads/TurboVNC.repo && \
     mv TurboVNC.repo /etc/yum.repos.d/ && \
-    yum install -y turbovnc && \
-    pip install websockify
+    yum install -y turbovnc
 
 
 # Install for Rstudio App


### PR DESCRIPTION
websockify have a dependency of numpy and show this error:
```
#5 191.8 Complete!
#5 192.1 Collecting websockify
#5 193.7   Downloading https://files.pythonhosted.org/packages/1e/2c/ac19ddaeb9aa76b6ce6678f073008a4123050001a812a5d173189fc4440a/websockify-0.10.0.tar.gz (40kB)
#5 194.1 Collecting numpy (from websockify)
#5 195.7   Downloading https://files.pythonhosted.org/packages/64/4a/b008d1f8a7b9f5206ecf70a53f84e654707e7616a771d84c05151a4713e9/numpy-1.22.3.zip (11.5MB)
#5 203.1     Complete output from command python setup.py egg_info:
#5 203.1     Traceback (most recent call last):
#5 203.1       File "<string>", line 1, in <module>
#5 203.1       File "/tmp/pip-build-Y1mFtC/numpy/setup.py", line 59
#5 203.1         raise RuntimeError(f'Cannot parse version {FULLVERSION}')
#5 203.1                 
```
If I add a version of numpy with pip, i.e. 1.12 before websockify dependency issue is not appearing and build is complete without errors.